### PR TITLE
feat: Add conflict detection and resolution (#2)

### DIFF
--- a/src/engram/cli.py
+++ b/src/engram/cli.py
@@ -445,6 +445,43 @@ def cmd_add(args):
         print(f"   Topics: {', '.join(topics)}")
 
 
+def cmd_conflicts(args):
+    """List and manage detected conflicts."""
+    cfg = load_config(args.config)
+    conflicts_file = cfg.memory_dir / "conflicts.md"
+    
+    if not conflicts_file.exists():
+        print("No conflicts detected yet.")
+        return
+    
+    content = conflicts_file.read_text()
+    
+    # Count conflicts
+    unresolved = content.count("**Status:** Unresolved")
+    resolved = content.count("**Status:** Resolved")
+    
+    print(f"⚠️ Conflicts Summary")
+    print(f"  Unresolved: {unresolved}")
+    print(f"  Resolved:   {resolved}")
+    print(f"  Total:      {unresolved + resolved}")
+    
+    if args.show:
+        print(f"\n--- conflicts.md ---\n")
+        print(content)
+    
+    if args.clear_resolved:
+        # Remove resolved conflicts from file
+        lines = content.split("\n## ")
+        header = lines[0]
+        conflicts = lines[1:] if len(lines) > 1 else []
+        
+        unresolved_conflicts = [c for c in conflicts if "**Status:** Unresolved" in c]
+        
+        new_content = header + "\n## ".join([""] + unresolved_conflicts) if unresolved_conflicts else header
+        conflicts_file.write_text(new_content.strip() + "\n")
+        print(f"  Cleared {resolved} resolved conflicts.")
+
+
 def cmd_stats(args):
     """Show garden statistics."""
     cfg = load_config(args.config)
@@ -599,6 +636,12 @@ def main():
     p_add.add_argument("--date", "-d", help="Date (default: today)")
     p_add.add_argument("--topics", help="Comma-separated topics for context-aware injection")
     p_add.set_defaults(func=cmd_add)
+    
+    # conflicts
+    p_conflicts = sub.add_parser("conflicts", help="List and manage detected conflicts")
+    p_conflicts.add_argument("--show", action="store_true", help="Show full conflicts.md")
+    p_conflicts.add_argument("--clear-resolved", action="store_true", help="Remove resolved conflicts from file")
+    p_conflicts.set_defaults(func=cmd_conflicts)
 
     # stats
     p_stats = sub.add_parser("stats", help="Show garden statistics")

--- a/src/engram/cli.py
+++ b/src/engram/cli.py
@@ -402,6 +402,49 @@ def cmd_beliefs(args):
             print(model.format_readable())
 
 
+def cmd_add(args):
+    """Add a fact manually with provenance tracking."""
+    from .core import append_to_graph, MEMORY_DIR
+    from datetime import date, datetime
+    import os
+    
+    cfg = load_config(args.config)
+    
+    # Parse fact into triplet
+    fact = args.fact
+    
+    # Build triplet
+    triplet = {
+        "subject": args.subject or "Marcus",  # Default subject
+        "predicate": args.predicate or "noted",
+        "object": fact,
+        "detail": args.detail or "",
+    }
+    
+    # Build provenance
+    provenance = {
+        "source": args.source or "manual",
+        "agent": args.agent or os.environ.get("AGENT_ID", "user"),
+        "confidence": args.confidence or 0.9,
+    }
+    
+    date_str = args.date or date.today().isoformat()
+    
+    # Add to graph
+    append_to_graph([triplet], date_str, provenance=provenance)
+    
+    print(f"✅ Added fact with provenance:")
+    print(f"   {triplet['subject']} → {triplet['predicate']} → {triplet['object']}")
+    print(f"   Source: {provenance['source']}")
+    print(f"   Agent: {provenance['agent']}")
+    print(f"   Confidence: {provenance['confidence']}")
+    
+    # Optionally add topics
+    if args.topics:
+        topics = [t.strip() for t in args.topics.split(",")]
+        print(f"   Topics: {', '.join(topics)}")
+
+
 def cmd_stats(args):
     """Show garden statistics."""
     cfg = load_config(args.config)
@@ -543,6 +586,19 @@ def main():
     p_beliefs.add_argument("--json", action="store_true", help="Output as JSON")
     p_beliefs.add_argument("--weak", action="store_true", help="Show only weakening beliefs")
     p_beliefs.set_defaults(func=cmd_beliefs)
+    
+    # add (manual fact with provenance)
+    p_add = sub.add_parser("add", help="Add a fact manually with provenance tracking")
+    p_add.add_argument("fact", help="The fact to add")
+    p_add.add_argument("--subject", "-s", help="Subject entity (default: Marcus)")
+    p_add.add_argument("--predicate", "-p", help="Relationship verb (default: noted)")
+    p_add.add_argument("--detail", help="Additional context")
+    p_add.add_argument("--source", help="Source (e.g., 'twitter:@anthropic', 'file:doc.md', 'url:https://...')")
+    p_add.add_argument("--agent", help="Agent that recorded this (default: from AGENT_ID env)")
+    p_add.add_argument("--confidence", type=float, help="Confidence 0.0-1.0 (default: 0.9)")
+    p_add.add_argument("--date", "-d", help="Date (default: today)")
+    p_add.add_argument("--topics", help="Comma-separated topics for context-aware injection")
+    p_add.set_defaults(func=cmd_add)
 
     # stats
     p_stats = sub.add_parser("stats", help="Show garden statistics")

--- a/src/engram/conflicts.py
+++ b/src/engram/conflicts.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""
+Conflict detection and resolution for MindGardener.
+
+Detects when new facts contradict existing facts and provides
+resolution strategies.
+"""
+
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+from .filelock import file_lock, safe_append
+
+
+# Predicates that indicate state (only one value can be true at a time)
+STATE_PREDICATES = {
+    "works_at", "lives_in", "status", "role", "title", "position",
+    "employed_by", "member_of", "located_in", "married_to", "dating",
+}
+
+# Predicates that can have multiple values
+ADDITIVE_PREDICATES = {
+    "knows", "contacted", "applied_to", "submitted_pr", "merged_pr",
+    "worked_on", "contributed_to", "mentioned", "discussed",
+}
+
+
+class Conflict:
+    """Represents a detected conflict between facts."""
+    
+    def __init__(
+        self,
+        subject: str,
+        predicate: str,
+        old_value: str,
+        new_value: str,
+        old_provenance: dict,
+        new_provenance: dict,
+    ):
+        self.subject = subject
+        self.predicate = predicate
+        self.old_value = old_value
+        self.new_value = new_value
+        self.old_provenance = old_provenance
+        self.new_provenance = new_provenance
+        self.detected_at = datetime.now().isoformat()
+        self.resolved = False
+        self.resolution = None
+    
+    def to_dict(self) -> dict:
+        return {
+            "subject": self.subject,
+            "predicate": self.predicate,
+            "old_value": self.old_value,
+            "new_value": self.new_value,
+            "old_provenance": self.old_provenance,
+            "new_provenance": self.new_provenance,
+            "detected_at": self.detected_at,
+            "resolved": self.resolved,
+            "resolution": self.resolution,
+        }
+    
+    def __str__(self) -> str:
+        return (
+            f"Conflict: {self.subject} {self.predicate}\n"
+            f"  Old: {self.old_value} (confidence: {self.old_provenance.get('confidence', '?')})\n"
+            f"  New: {self.new_value} (confidence: {self.new_provenance.get('confidence', '?')})"
+        )
+
+
+def is_conflicting_predicate(predicate: str) -> bool:
+    """Check if predicate represents state that can only have one value."""
+    pred_lower = predicate.lower().replace("_", "")
+    for state_pred in STATE_PREDICATES:
+        if state_pred.replace("_", "") in pred_lower:
+            return True
+    return False
+
+
+def find_existing_fact(
+    graph_file: Path,
+    subject: str,
+    predicate: str,
+) -> Optional[dict]:
+    """Find the most recent fact for subject+predicate."""
+    if not graph_file.exists():
+        return None
+    
+    matches = []
+    for line in graph_file.read_text().strip().split('\n'):
+        if not line:
+            continue
+        try:
+            fact = json.loads(line)
+            if (fact.get("subject") == subject and 
+                fact.get("predicate") == predicate):
+                matches.append(fact)
+        except json.JSONDecodeError:
+            continue
+    
+    if not matches:
+        return None
+    
+    # Return most recent by timestamp
+    return max(matches, key=lambda f: f.get("provenance", {}).get("timestamp", ""))
+
+
+def detect_conflict(
+    graph_file: Path,
+    new_triplet: dict,
+    new_provenance: dict,
+) -> Optional[Conflict]:
+    """
+    Check if new triplet conflicts with existing facts.
+    
+    Returns Conflict if detected, None otherwise.
+    """
+    subject = new_triplet.get("subject")
+    predicate = new_triplet.get("predicate")
+    new_value = new_triplet.get("object")
+    
+    # Only check state predicates for conflicts
+    if not is_conflicting_predicate(predicate):
+        return None
+    
+    existing = find_existing_fact(graph_file, subject, predicate)
+    if not existing:
+        return None
+    
+    old_value = existing.get("object")
+    
+    # No conflict if values are the same
+    if old_value == new_value:
+        return None
+    
+    # Conflict detected!
+    return Conflict(
+        subject=subject,
+        predicate=predicate,
+        old_value=old_value,
+        new_value=new_value,
+        old_provenance=existing.get("provenance", {}),
+        new_provenance=new_provenance,
+    )
+
+
+def log_conflict(conflicts_file: Path, conflict: Conflict):
+    """Log conflict to conflicts.md for human review."""
+    with file_lock(conflicts_file):
+        # Create file if doesn't exist
+        if not conflicts_file.exists():
+            conflicts_file.write_text("# Detected Conflicts\n\n")
+        
+        # Append conflict entry
+        entry = f"""
+## {conflict.subject} → {conflict.predicate} ({conflict.detected_at[:10]})
+
+| | Old | New |
+|---|-----|-----|
+| Value | {conflict.old_value} | {conflict.new_value} |
+| Source | {conflict.old_provenance.get('source', '?')} | {conflict.new_provenance.get('source', '?')} |
+| Confidence | {conflict.old_provenance.get('confidence', '?')} | {conflict.new_provenance.get('confidence', '?')} |
+| Agent | {conflict.old_provenance.get('agent', '?')} | {conflict.new_provenance.get('agent', '?')} |
+
+**Status:** Unresolved
+
+---
+"""
+        with open(conflicts_file, "a") as f:
+            f.write(entry)
+
+
+def resolve_conflict(
+    conflict: Conflict,
+    strategy: str = "latest_wins",
+) -> dict:
+    """
+    Resolve a conflict using the specified strategy.
+    
+    Strategies:
+    - latest_wins: Newer timestamp wins
+    - confidence_wins: Higher confidence wins
+    - keep_both: Mark both as valid (for human review)
+    
+    Returns the winning fact.
+    """
+    old_ts = conflict.old_provenance.get("timestamp", "")
+    new_ts = conflict.new_provenance.get("timestamp", "")
+    old_conf = conflict.old_provenance.get("confidence", 0.5)
+    new_conf = conflict.new_provenance.get("confidence", 0.5)
+    
+    if strategy == "latest_wins":
+        winner = "new" if new_ts >= old_ts else "old"
+    elif strategy == "confidence_wins":
+        winner = "new" if new_conf >= old_conf else "old"
+    elif strategy == "keep_both":
+        winner = "both"
+    else:
+        winner = "new"  # Default to latest
+    
+    conflict.resolved = True
+    conflict.resolution = {
+        "strategy": strategy,
+        "winner": winner,
+        "resolved_at": datetime.now().isoformat(),
+    }
+    
+    if winner == "new":
+        return {
+            "subject": conflict.subject,
+            "predicate": conflict.predicate,
+            "object": conflict.new_value,
+            "provenance": conflict.new_provenance,
+        }
+    elif winner == "old":
+        return {
+            "subject": conflict.subject,
+            "predicate": conflict.predicate,
+            "object": conflict.old_value,
+            "provenance": conflict.old_provenance,
+        }
+    else:
+        # keep_both - return new but mark as conflicted
+        return {
+            "subject": conflict.subject,
+            "predicate": conflict.predicate,
+            "object": conflict.new_value,
+            "provenance": conflict.new_provenance,
+            "conflicted": True,
+            "alternative": conflict.old_value,
+        }

--- a/src/engram/core.py
+++ b/src/engram/core.py
@@ -54,7 +54,7 @@ EXTRACT_PROMPT = """Extract structured knowledge from this daily log. Output ONL
     }
   ],
   "triplets": [
-    {"subject": "Entity1", "predicate": "verb_phrase", "object": "Entity2", "detail": "context"}
+    {"subject": "Entity1", "predicate": "verb_phrase", "object": "Entity2", "detail": "context", "confidence": 0.9}
   ],
   "events": [
     {"description": "what happened", "entities": ["Entity1"], "significance": "low|medium|high"}
@@ -259,8 +259,14 @@ def update_entity_file(name: str, entity_type: str, facts: list,
         print(f"  Created: {filename}.md")
 
 
-def append_to_graph(triplets: list, date_str: str):
-    """Append triplets to graph.jsonl with dedup."""
+def append_to_graph(triplets: list, date_str: str, provenance: dict = None):
+    """Append triplets to graph.jsonl with dedup and provenance tracking.
+    
+    Args:
+        triplets: List of triplet dicts with subject, predicate, object, detail
+        date_str: Date string (YYYY-MM-DD)
+        provenance: Optional dict with source, agent, confidence fields
+    """
     existing = set()
     if GRAPH_FILE.exists():
         for line in GRAPH_FILE.read_text().strip().split('\n'):
@@ -271,6 +277,16 @@ def append_to_graph(triplets: list, date_str: str):
                 except:
                     pass
     
+    # Build default provenance if not provided
+    if provenance is None:
+        provenance = {}
+    default_provenance = {
+        "source": provenance.get("source", f"file:memory/{date_str}.md"),
+        "agent": provenance.get("agent", os.environ.get("AGENT_ID", "unknown")),
+        "confidence": provenance.get("confidence", 0.8),
+        "timestamp": datetime.now().isoformat(),
+    }
+    
     new_count = 0
     with file_lock(GRAPH_FILE):
         with open(GRAPH_FILE, "a") as f:
@@ -278,12 +294,16 @@ def append_to_graph(triplets: list, date_str: str):
                 key = (date_str, t["subject"], t["predicate"], t["object"])
                 if key not in existing:
                     t["date"] = date_str
-                    t["timestamp"] = datetime.now().isoformat()
+                    t["provenance"] = {
+                        **default_provenance,
+                        # Allow triplet-level confidence override
+                        "confidence": t.pop("confidence", default_provenance["confidence"]),
+                    }
                     f.write(json.dumps(t) + "\n")
                     new_count += 1
     
     if new_count:
-        print(f"  Added {new_count} new triplets to graph.jsonl")
+        print(f"  Added {new_count} new triplets to graph.jsonl (provenance: {default_provenance['source']})")
 
 
 MAX_CHUNK_SIZE = int(os.environ.get("ENGRAM_MAX_CHUNK", "6000"))
@@ -442,7 +462,13 @@ def process_date(date_str: str):
         )
     
     if triplets:
-        append_to_graph(triplets, date_str)
+        # Add provenance metadata
+        provenance = {
+            "source": f"file:memory/{date_str}.md",
+            "agent": os.environ.get("AGENT_ID", "unknown"),
+            "confidence": 0.8,  # Default confidence for LLM extraction
+        }
+        append_to_graph(triplets, date_str, provenance=provenance)
 
 
 def run_surprise(date_str: str):

--- a/src/engram/core.py
+++ b/src/engram/core.py
@@ -28,6 +28,7 @@ from datetime import datetime, date
 from pathlib import Path
 
 from .filelock import file_lock, safe_write, safe_append
+from .conflicts import detect_conflict, log_conflict, resolve_conflict, Conflict
 
 # Configuration — each agent sets its own workspace
 WORKSPACE = Path(os.environ.get("GARDENER_WORKSPACE", "/root/clawd"))
@@ -259,14 +260,25 @@ def update_entity_file(name: str, entity_type: str, facts: list,
         print(f"  Created: {filename}.md")
 
 
-def append_to_graph(triplets: list, date_str: str, provenance: dict = None):
-    """Append triplets to graph.jsonl with dedup and provenance tracking.
+def append_to_graph(
+    triplets: list, 
+    date_str: str, 
+    provenance: dict = None,
+    conflict_strategy: str = "latest_wins",
+    conflicts_file: Path = None,
+):
+    """Append triplets to graph.jsonl with dedup, provenance, and conflict detection.
     
     Args:
         triplets: List of triplet dicts with subject, predicate, object, detail
         date_str: Date string (YYYY-MM-DD)
         provenance: Optional dict with source, agent, confidence fields
+        conflict_strategy: How to resolve conflicts (latest_wins, confidence_wins, keep_both)
+        conflicts_file: Path to conflicts.md (default: memory/conflicts.md)
     """
+    if conflicts_file is None:
+        conflicts_file = MEMORY_DIR / "conflicts.md"
+    
     existing = set()
     if GRAPH_FILE.exists():
         for line in GRAPH_FILE.read_text().strip().split('\n'):
@@ -288,22 +300,46 @@ def append_to_graph(triplets: list, date_str: str, provenance: dict = None):
     }
     
     new_count = 0
+    conflict_count = 0
+    
     with file_lock(GRAPH_FILE):
         with open(GRAPH_FILE, "a") as f:
             for t in triplets:
                 key = (date_str, t["subject"], t["predicate"], t["object"])
                 if key not in existing:
-                    t["date"] = date_str
-                    t["provenance"] = {
+                    triplet_provenance = {
                         **default_provenance,
-                        # Allow triplet-level confidence override
                         "confidence": t.pop("confidence", default_provenance["confidence"]),
                     }
+                    
+                    # Check for conflicts with existing facts
+                    conflict = detect_conflict(GRAPH_FILE, t, triplet_provenance)
+                    if conflict:
+                        conflict_count += 1
+                        print(f"  ⚠️ Conflict detected: {conflict.subject} {conflict.predicate}")
+                        print(f"     Old: {conflict.old_value}")
+                        print(f"     New: {conflict.new_value}")
+                        
+                        # Log conflict for human review
+                        log_conflict(conflicts_file, conflict)
+                        
+                        # Resolve based on strategy
+                        resolved = resolve_conflict(conflict, conflict_strategy)
+                        if resolved.get("conflicted"):
+                            t["conflicted"] = True
+                            t["alternative"] = resolved.get("alternative")
+                    
+                    t["date"] = date_str
+                    t["provenance"] = triplet_provenance
                     f.write(json.dumps(t) + "\n")
                     new_count += 1
     
     if new_count:
-        print(f"  Added {new_count} new triplets to graph.jsonl (provenance: {default_provenance['source']})")
+        msg = f"  Added {new_count} new triplets to graph.jsonl"
+        if conflict_count:
+            msg += f" ({conflict_count} conflicts detected, logged to conflicts.md)"
+        msg += f" (provenance: {default_provenance['source']})"
+        print(msg)
 
 
 MAX_CHUNK_SIZE = int(os.environ.get("ENGRAM_MAX_CHUNK", "6000"))


### PR DESCRIPTION
## Summary
Implements issue #2: Conflict detection when new facts contradict existing ones.

## New Module: conflicts.py
- `STATE_PREDICATES`: predicates that can only have one value (works_at, lives_in, status, etc.)
- `detect_conflict()`: checks if new fact contradicts existing
- `log_conflict()`: writes to memory/conflicts.md for human review
- `resolve_conflict()`: strategies (latest_wins, confidence_wins, keep_both)

## Changes
- `append_to_graph()` now detects conflicts before adding
- Conflicts logged with old/new values, provenance, confidence
- New CLI: `garden conflicts` to view/manage

## Example
```bash
garden add "Employed at Spotify" --subject Marcus --predicate works_at
garden add "Unemployed" --subject Marcus --predicate works_at
# ⚠️ Conflict detected: Marcus works_at
#    Old: Employed at Spotify
#    New: Unemployed
```

## conflicts.md Output
| | Old | New |
|---|-----|-----|
| Value | Employed at Spotify | Unemployed |
| Source | test:conflict | test:conflict2 |
| Confidence | 0.7 | 0.9 |

## Resolution Strategies
- `latest_wins`: Newer timestamp wins (default)
- `confidence_wins`: Higher confidence wins
- `keep_both`: Mark as conflicted for human review

Closes #2